### PR TITLE
Ensure all bytes of a message are received

### DIFF
--- a/lib/krakow/connection.rb
+++ b/lib/krakow/connection.rb
@@ -139,7 +139,7 @@ module Krakow
         debug "<<< #{buf.inspect}"
         struct = FrameType.decode(buf)
         debug "Decoded structure: #{struct.inspect}"
-        struct[:data] = socket.recv(struct[:size])
+        struct[:data] = socket.read(struct[:size])
         debug "<<< #{struct[:data].inspect}"
         @receiving = false
         frame = FrameType.build(struct)


### PR DESCRIPTION
`#recv` only has to provide up to the amount of requested bytes so it can terminate on large messages. Use `#read` instead which delivers exactly the requested number of bytes.
