### PR TITLE
Support for http (gem) v1 - using #headers instead of #with

### DIFF
--- a/lib/krakow/discovery.rb
+++ b/lib/krakow/discovery.rb
@@ -32,7 +32,7 @@ module Krakow
         uri.query = "topic=#{topic}&ts=#{Time.now.to_i}"
         begin
           debug "Requesting lookup for topic #{topic} - #{uri}"
-          content = HTTP.with(:accept => 'application/octet-stream').get(uri.to_s)
+          content = HTTP.headers(:accept => 'application/octet-stream').get(uri.to_s)
           unless(content.respond_to?(:to_hash))
             data = MultiJson.load(content.to_s)
           else


### PR DESCRIPTION
The http gem v1 removed the `#with` deprecated method. It was used to set the
`"Accept"` header in the request to nsqlookupd. Replaces it with `#headers`
should do the trick.

See: https://github.com/httprb/http/blob/master/CHANGES.md#100-2015-12-25
