### PR TITLE
GET request to nsqlookupd times out

### DIFF
--- a/lib/krakow/discovery.rb
+++ b/lib/krakow/discovery.rb
@@ -32,7 +32,9 @@ module Krakow
         uri.query = "topic=#{topic}&ts=#{Time.now.to_i}"
         begin
           debug "Requesting lookup for topic #{topic} - #{uri}"
-          content = HTTP.with(:accept => 'application/octet-stream').get(uri.to_s)
+          content = HTTP.timeout(:global, :write => 2, :connect => 2, :read => 2)
+                        .headers(:accept => 'application/octet-stream')
+                        .get(uri.to_s)
           unless(content.respond_to?(:to_hash))
             data = MultiJson.load(content.to_s)
           else


### PR DESCRIPTION
Krakow makes a request to lookupd to get the list of nsqd nodes. If for any
reason lookupd takes a long time to respond Krakow will wait forever.

Even worst, it seems that this requests block the flow of NSQ messages from
the already discovered nsqd nodes.

Possible fix to [#31 Krakow stops processing messages](https://github.com/chrisroberts/krakow/issues/31#issuecomment-197373849)
